### PR TITLE
Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: 'The output directory for sign, default to build/signed'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/